### PR TITLE
surround qw with deprecated (modern syntax)

### DIFF
--- a/ldap-stats.pl
+++ b/ldap-stats.pl
@@ -1028,7 +1028,7 @@ $printstr .= $operations{MODRDN}{DATA}   ? $operations{MODRDN}{SPACING}   : q{};
 $printstr .= $operations{DEL}{DATA}      ? $operations{DEL}{SPACING}      : q{};
 print "$printstr\n";
 
-for my $index qw( Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec) {
+for my $index (qw(Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec)) {
     if ( defined $months{$index} || $printmonths ) {
         printf '  %-11s', $index;
         if ( $operations{CONNECT}{DATA} ) {


### PR DESCRIPTION
Running ldap-stats on perl 5.16 (on RHEL 7), I get the following error:
`Use of qw(...) as parentheses is deprecated at ldap-stats line 1032.`

Running ldap-stats on perl 5.28 (Fedora 30), I get:
`syntax error at ldap-stats.pl line 1031, near "$index qw( Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec)"`

Wrapping the qw(...) in parentheses fixes this issue.